### PR TITLE
Setup remix to call strapi api with auth header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+STRAPI_TOKEN=token_from_strapi_admin_console

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "singleQuote": true,
+    "trailingComma": "all",
+    "tabWidth": 4
+}

--- a/app/data.server.ts
+++ b/app/data.server.ts
@@ -17,6 +17,12 @@ export type ContactRecord = ContactMutation & {
     createdAt: string;
 };
 
+function strapiHeaders() {
+    return {
+        Authorization: `Bearer ${process.env.STRAPI_TOKEN!}`,
+    };
+}
+
 export async function getContacts(q?: string | null) {
     const query = qs.stringify({
         filters: {
@@ -33,10 +39,12 @@ export async function getContacts(q?: string | null) {
     });
 
     try {
-        const response = await fetch(STRAPI_URL + '/api/contacts?' + query);
+        const response = await fetch(STRAPI_URL + '/api/contacts?' + query, {
+            headers: strapiHeaders(),
+        });
         const data = await response.json();
         const flattenContactsAttributesData = flattenContactsAttributes(
-            data.data
+            data.data,
         );
 
         return flattenContactsAttributesData;
@@ -52,12 +60,13 @@ export async function createContact(data: any) {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
+                ...strapiHeaders(),
             },
             body: JSON.stringify({ data: { ...data } }),
         });
         const responseData = await response.json();
         const flattenContactsAttributesData = flattenContactsAttributes(
-            responseData.data
+            responseData.data,
         );
 
         return flattenContactsAttributesData;
@@ -69,10 +78,12 @@ export async function createContact(data: any) {
 
 export async function getContact(id: string) {
     try {
-        const response = await fetch(STRAPI_URL + '/api/contacts/' + id);
+        const response = await fetch(STRAPI_URL + '/api/contacts/' + id, {
+            headers: strapiHeaders(),
+        });
         const data = await response.json();
         const flattenContactsAttributesData = flattenContactsAttributes(
-            data.data
+            data.data,
         );
 
         return flattenContactsAttributesData;
@@ -88,12 +99,13 @@ export async function updateContactById(id: string, updates: ContactMutation) {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
+                ...strapiHeaders(),
             },
             body: JSON.stringify({ data: { ...updates } }),
         });
         const responseData = await response.json();
         const flattenContactsAttributesData = flattenContactsAttributes(
-            responseData.data
+            responseData.data,
         );
 
         return flattenContactsAttributesData;
@@ -107,10 +119,11 @@ export async function deleteContact(id: string) {
     try {
         const response = await fetch(STRAPI_URL + '/api/contacts/' + id, {
             method: 'DELETE',
+            headers: strapiHeaders(),
         });
         const data = await response.json();
         const flattenContactsAttributesData = flattenContactsAttributes(
-            data.data
+            data.data,
         );
 
         return flattenContactsAttributesData;

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-plugin-jsx-a11y": "^6.8.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "prettier": "^3.2.5",
         "typescript": "^5.1.6",
         "vite": "^5.1.4",
         "vite-tsconfig-paths": "^4.3.1"
@@ -1508,6 +1509,21 @@
         "wrangler": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@remix-run/express": {
@@ -8249,15 +8265,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "prettier": "^3.2.5",
     "typescript": "^5.1.6",
     "vite": "^5.1.4",
     "vite-tsconfig-paths": "^4.3.1"


### PR DESCRIPTION
When calling the strapi API (either locally or in the cloud), you need to provide an API token via `Authorization: Bearer <token>` header.

This PR updates the fetch calls to include the correct headers.

Copy `.env.example` to `.env` and paste in the API key generated from your admin console.

>NOTE: You must also be running Strapi locally on `http://localhost:1337` or in the cloud. If in cloud, make sure you add `STRAPI_URL` to your `.env` file.